### PR TITLE
configure routes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -140,6 +140,13 @@ export class App {
   }
 
   public addRoute (targetPrefix: string, peerId: string) {
+    logger.info('adding route', { targetPrefix, peerId })
+    const peer = this.connector.routeManager.getPeer(peerId)
+    if (!peer) {
+      const msg = 'Cannot add route for unknown peerId=' + peerId
+      logger.error(msg)
+      throw new Error(msg)
+    }
     this.connector.routeManager.addRoute({
       peer: peerId,
       prefix: targetPrefix,

--- a/src/app.ts
+++ b/src/app.ts
@@ -139,6 +139,14 @@ export class App {
     return this._businessRulesMap.get(peerId) || []
   }
 
+  public addRoute (targetPrefix: string, peerId: string) {
+    this.connector.routeManager.addRoute({
+      peer: peerId,
+      prefix: targetPrefix,
+      path: []
+    })
+  }
+
   /**
    * Creates the business rules specified in the peer information. Custom rules should be added to the list.
    * @param peerInfo Peer information

--- a/src/schemas/Config.json
+++ b/src/schemas/Config.json
@@ -127,6 +127,29 @@
       "description": "Host to bind to. Warning: The admin API interface is public by default: '0.0.0.0'",
       "type": "string",
       "default": "0.0.0.0"
+    },
+    "routes": {
+      "description": "Preconfigured routes to add to the connector's routing table.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "description": "Description of a route entry.",
+        "type": "object",
+        "properties": {
+          "targetPrefix": {
+            "description": "ILP address prefix that this route applies to. Configured routes take precedence over the same or shorter prefixes that are local or published by peers. More specific prefixes will still take precedence. Prefixes should NOT include a trailing period.",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9._~-]+$"
+          },
+          "peerId": {
+            "description": "ID of the account that destinations matching `targetPrefix` should be forwarded to. Must be one of the peers in `peers`.",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9._~-]+$"
+          }
+        },
+        "required": ["targetPrefix", "peerId"],
+        "additionalProperties": false
+      }
     }
   },
   "required": ["peers"],

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -46,7 +46,8 @@ export class AdminApi {
       { method: 'GET', match: '/balance$', fn: this.getBalances },
       { method: 'POST', match: '/balance$', fn: this.updateBalance },
       { method: 'POST', match: '/peer$', fn: this.addPeer },
-      { method: 'GET', match: '/peer$', fn: this.getPeer }
+      { method: 'GET', match: '/peer$', fn: this.getPeer },
+      { method: 'GET', match: '/routes$', fn: this.getRoutes }
     ]
 
     if (host) this.host = host
@@ -162,6 +163,10 @@ export class AdminApi {
 
   private async getPeer () {
     return this.app.connector.getPeerList()
+  }
+
+  private async getRoutes () {
+    return this.app.connector.routingTable.getRoutingTable()['items']
   }
 
   /**

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -79,7 +79,7 @@ export class Config extends ConfigSchemaTyping {
             try {
               config[key] = JSON.parse(envValue)
             } catch (err) {
-              logger.error('unable to parse config. key=%s', envKey)
+              logger.error('unable to parse config. key=%s' + envKey)
             }
             break
           case 'boolean':
@@ -96,7 +96,7 @@ export class Config extends ConfigSchemaTyping {
     }
 
     for (const key of unrecognizedEnvKeys) {
-      logger.warn('unrecognized environment variable. key=%s', key)
+      logger.warn('unrecognized environment variable. key=' + key)
     }
 
     this.validate(config)
@@ -117,6 +117,16 @@ export class Config extends ConfigSchemaTyping {
         : { message: 'unknown validation error', dataPath: '' }
       throw new InvalidJsonBodyError('config failed to validate. error=' + firstError.message + ' dataPath=' + firstError.dataPath, this._validate.errors || [])
     }
+
+    // check that a peer exists for preconfigured routes
+    const routes: {targetPrefix: string, peerId: string}[] = config['routes'] || []
+    routes.forEach(entry => {
+      if (!config['peers'][entry.peerId]) {
+        const err = 'No peer configured for pre-configured route: ' + JSON.stringify(entry)
+        logger.error(err)
+        throw new Error(err)
+      }
+    })
   }
 
   get (key: string) {

--- a/src/start.ts
+++ b/src/start.ts
@@ -69,6 +69,10 @@ const start = async () => {
 
   // load peers from config
   Object.keys(config.peers || {}).forEach(peer => app.addPeer(config.peers[peer], config.peers[peer]['endpoint']))
+
+  // load pre-configured routes
+  const routes: {targetPrefix: string, peerId: string}[] = config['routes'] || []
+  routes.forEach(entry => app.addRoute(entry.targetPrefix, entry.peerId))
 }
 if (!module.parent) {
   start().catch(e => {

--- a/src/start.ts
+++ b/src/start.ts
@@ -70,7 +70,7 @@ const start = async () => {
   // load peers from config
   Object.keys(config.peers || {}).forEach(peer => app.addPeer(config.peers[peer], config.peers[peer]['endpoint']))
 
-  // load pre-configured routes
+  // load pre-configured routes. Must be done after the pre-configured peers have been loaded.
   const routes: {targetPrefix: string, peerId: string}[] = config['routes'] || []
   routes.forEach(entry => app.addRoute(entry.targetPrefix, entry.peerId))
 }

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -273,6 +273,12 @@ describe('Test App', function () {
 
       assert.include(app.connector.routingTable.getRoutingTable()['prefixes'], 'test.alice')
     })
+
+    it('throws error if specified peer does not exist', async function () {
+      assert.throws(() => {
+        app.addRoute('test.unknown.peer', 'unknownPeer')
+      }, 'Cannot add route for unknown peerId=unknownPeer')
+    })
   })
 
 })

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -265,4 +265,14 @@ describe('Test App', function () {
     })
   })
 
+  describe('add route', function () {
+    it('adds the route to the connectors routing table', async function () {
+      assert.notInclude(app.connector.routingTable.getRoutingTable()['prefixes'], 'test.alice')
+
+      app.addRoute('test.alice', 'alice')
+
+      assert.include(app.connector.routingTable.getRoutingTable()['prefixes'], 'test.alice')
+    })
+  })
+
 })

--- a/test/services/admin-api.test.ts
+++ b/test/services/admin-api.test.ts
@@ -260,4 +260,33 @@ describe('Admin Api', function () {
       sinon.assert.calledWith(addPeerSpy, peerInfo, endpointInfo)
     })
   })
+
+  describe('getRoutes', function () {
+    it('returns the routing table', async function () {
+      const peerInfo: PeerInfo = {
+        id: 'alice',
+        assetCode: 'USD',
+        assetScale: 2,
+        relation: 'peer',
+        rules: [],
+        protocols: []
+      }
+      const endpointInfo: EndpointInfo = {
+        type: "http",
+        url: 'http://localhost:8084'
+      }
+      app.addPeer(peerInfo, endpointInfo)
+      app.addRoute('test.rafiki.alice', 'alice')
+
+      const response = await axios.get('http://127.0.0.1:7780/routes')
+      
+      assert.equal(response.status, 200)
+      assert.deepEqual(response.data, {
+        "test.rafiki.alice": {
+            "nextHop": "alice",
+            "path": []
+        }
+      })
+    })
+  })
 })

--- a/test/services/config.test.ts
+++ b/test/services/config.test.ts
@@ -40,88 +40,124 @@ describe('Config', function () {
     }
   }
 
-  beforeEach(function () {
-    process.env.CONNECTOR_PEERS = JSON.stringify(peers)
-    process.env.CONNECTOR_MAX_HOLD_TIME = '2000'
-    process.env.CONNECTOR_MIN_MESSAGE_WINDOW = '2000'
+  describe('peers', function () {
+    beforeEach(function () {
+      process.env.CONNECTOR_PEERS = JSON.stringify(peers)
+      process.env.CONNECTOR_MAX_HOLD_TIME = '2000'
+      process.env.CONNECTOR_MIN_MESSAGE_WINDOW = '2000'
+    })
+  
+    afterEach(() => {
+      process.env = Object.assign({}, env)
+    })
+  
+    it('parses peers from env variables', function () {
+      const config = new Config()
+  
+      config.loadFromEnv()
+  
+      assert.deepEqual(<any>config.peers, peers)
+    })
+  
+    it('parses peers from opts', function () {
+      const config = new Config()
+  
+      config.loadFromOpts({ peers })
+  
+      assert.deepEqual(<any>config.peers, peers)
+    })
+  
+    it('can be used to create peers on app', async function () {
+      const config = new Config()
+      config.loadFromEnv()
+      const app = new App(config)
+  
+      Object.keys(config.peers).forEach(peer => app.addPeer(config.peers[peer], config.peers[peer]['endpoint']))
+  
+      assert.include(app.connector.getPeerList(), 'usd-ledger')
+      assert.include(app.connector.getPeerList(), 'eur-ledger')
+    })
   })
 
-  afterEach(() => {
-    process.env = Object.assign({}, env)
+  describe('routes', function () {
+    
+    it('parses routes correctly', function () {
+      const routes = [{
+        targetPrefix: 'test.rafiki.eur-ledger',
+        peerId: 'eur-ledger'
+      }, {
+        targetPrefix: 'test.rafiki.usd-ledger',
+        peerId: 'usd-ledger'
+      }]
+      process.env.CONNECTOR_PEERS = JSON.stringify(peers)
+      process.env.CONNECTOR_ROUTES = JSON.stringify(routes)
+      const config = new Config()
+      config.loadFromEnv()
+      assert.deepEqual(routes, config.get('routes'))
+    })
+  
+    it('won\'t parse routes with peer id format', function () {
+      const routes = [{
+        targetPrefix: 'test.rafiki.eur-ledger',
+        peerId: 'garbage!'
+      }, {
+        targetPrefix: 'test.rafiki.usd-ledger',
+        peerId: 'usd-ledger'
+      }]
+      process.env.CONNECTOR_PEERS = JSON.stringify(peers)
+      process.env.CONNECTOR_ROUTES = JSON.stringify(routes)
+      const config = new Config()
+      assert.throws(() => {
+        config.loadFromEnv()
+      }, 'config failed to validate. error=should match pattern "^[a-zA-Z0-9._~-]+$" dataPath=.routes[0].peerId')
+    })
+  
+    it('should not parse routes missing prefix', function () {
+      const routes = [{
+        targetPrefix: undefined,
+        peerId: 'garbage!'
+      }, {
+        targetPrefix: 'test.rafiki.usd-ledger',
+        peerId: 'usd-ledger'
+      }]
+      process.env.CONNECTOR_PEERS = JSON.stringify(peers)
+      process.env.CONNECTOR_ROUTES = JSON.stringify(routes)
+      const config = new Config()
+      assert.throws(() => {
+        config.loadFromEnv()
+      }, 'config failed to validate. error=should have required property \'targetPrefix\' dataPath=.routes[0]')
+    })
+  
+    it('should not parse routes missing peer id', function () {
+      const routes = [{
+        targetPrefix: 'test.rafiki.eur-ledger',
+        peerId: undefined
+      }, {
+        targetPrefix: 'test.rafiki.usd-ledger',
+        peerId: 'usd-ledger'
+      }]
+      process.env.CONNECTOR_PEERS = JSON.stringify(peers)
+      process.env.CONNECTOR_ROUTES = JSON.stringify(routes)
+  
+      const config = new Config()
+      assert.throws(() => {
+        config.loadFromEnv()
+      }, 'config failed to validate. error=should have required property \'peerId\' dataPath=.routes[0]')
+    })
+  
+    it('validates that peers appearing in preconfigured routes exist in the peer list', async function () {
+      const routes = [{
+        targetPrefix: 'test.rafiki.alice',
+        peerId: 'alice'
+      }]
+      process.env.CONNECTOR_PEERS = JSON.stringify(peers)
+      process.env.CONNECTOR_ROUTES = JSON.stringify(routes)
+
+      const config = new Config()
+      assert.throws(() => {
+        config.loadFromEnv()
+      }, 'No peer configured for pre-configured route: {"targetPrefix":"test.rafiki.alice","peerId":"alice"}')
+    })
   })
 
-  it('parses peers from env variables', function () {
-    const config = new Config()
-
-    config.loadFromEnv()
-
-    assert.deepEqual(<any>config.peers, peers)
-  })
-
-  it('parses peers from opts', function () {
-    const config = new Config()
-
-    config.loadFromOpts({ peers })
-
-    assert.deepEqual(<any>config.peers, peers)
-  })
-
-  it('can be used to create peers on app', async function () {
-    const config = new Config()
-    config.loadFromEnv()
-    const app = new App(config)
-
-    Object.keys(config.peers).forEach(peer => app.addPeer(config.peers[peer], config.peers[peer]['endpoint']))
-
-    assert.include(app.connector.getPeerList(), 'usd-ledger')
-    assert.include(app.connector.getPeerList(), 'eur-ledger')
-  })
-
-  // describe('connector routes', () => {
-  //   beforeEach(function () {
-  //     this.routes = [{
-  //       targetPrefix: 'a.',
-  //       peerId: 'example.a'
-  //     }]
-  //   })
-
-  //   afterEach(() => {
-  //     process.env = Object.assign({}, env)
-  //   })
-
-  //   it('parses routes correctly', function () {
-  //     process.env.CONNECTOR_ROUTES = JSON.stringify(this.routes)
-  //     const config = new Config()
-  //     config.loadFromEnv()
-  //     assert.deepEqual(this.routes, config.get('routes'))
-  //   })
-
-  //   it('won\'t parse routes with invalid ledger', function () {
-  //     this.routes[0].peerId = 'garbage!'
-  //     process.env.CONNECTOR_ROUTES = JSON.stringify(this.routes)
-  //     const config = new Config()
-  //     assert.throws(() => {
-  //       config.loadFromEnv()
-  //     }, 'config failed to validate. error=should match pattern "^[a-zA-Z0-9._~-]+$" dataPath=.routes[0].peerId')
-  //   })
-
-  //   it('should not parse routes missing prefix', function () {
-  //     this.routes[0].targetPrefix = undefined
-  //     process.env.CONNECTOR_ROUTES = JSON.stringify(this.routes)
-  //     const config = new Config()
-  //     assert.throws(() => {
-  //       config.loadFromEnv()
-  //     }, 'config failed to validate. error=should have required property \'targetPrefix\' dataPath=.routes[0]')
-  //   })
-
-  //   it('should not parse routes missing ledger', function () {
-  //     this.routes[0].peerId = undefined
-  //     process.env.CONNECTOR_ROUTES = JSON.stringify(this.routes)
-
-  //     const config = new Config()
-  //     assert.throws(() => {
-  //       config.loadFromEnv()
-  //     }, 'config failed to validate. error=should have required property \'peerId\' dataPath=.routes[0]')
-  //   })
-  // })
 })


### PR DESCRIPTION
* can read in pre-configured routes from config. Peer in pre-configured routes need to be in the pre-configured peer list as well.
* can get routes from admin-api can 